### PR TITLE
Use binary or operator for enabling TLS1.2

### DIFF
--- a/functions/Invoke-Method.ps1
+++ b/functions/Invoke-Method.ps1
@@ -87,7 +87,7 @@ function Invoke-Method {
 
     $uri = 'https://cloud.tenable.com/' + $Path.TrimStart('/')
 
-    [Net.ServicePointManager]::SecurityProtocol += [System.Net.SecurityProtocolType]::Tls12
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
     $multiplier = 0.5
     while (-not [String]::IsNullOrEmpty($uri)) {


### PR DESCRIPTION
Using `+=` technically works once but will keep incrementing the value enabling other versions and then overflowing. Not really sure why I used it.